### PR TITLE
Add check_url_duplicates option support

### DIFF
--- a/lib/uploadcare.rb
+++ b/lib/uploadcare.rb
@@ -16,6 +16,7 @@ module Uploadcare
     cache_files: true,
     autostore: :auto,
     auth_scheme: :secure,
+    check_url_duplicates: false,
   }
 
   def self.default_settings

--- a/lib/uploadcare/api/uploading_api/upload_params.rb
+++ b/lib/uploadcare/api/uploading_api/upload_params.rb
@@ -13,15 +13,16 @@ module Uploadcare
         {
           source_url: parse_url(url),
           pub_key: public_key,
-          store: store
-        }.reject { |k, v| v.nil? }
+          store: store,
+          check_URL_duplicates: check_url_duplicates
+        }.compact
       end
 
       def for_file_upload(files)
         {
           UPLOADCARE_PUB_KEY: public_key,
           UPLOADCARE_STORE: store
-        }.reject { |k, v| v.nil? }.merge(file_params(files))
+        }.compact.merge(file_params(files))
       end
 
       private
@@ -39,6 +40,14 @@ module Uploadcare
         per_request_value = request_options[:store]
 
         mapping[per_request_value] || mapping[global_value]
+      end
+
+      def check_url_duplicates
+        mapping = { true => 1, false => 0 }
+
+        return mapping[request_options[:check_url_duplicates]] if request_options.key?(:check_url_duplicates)
+
+        mapping[global_options[:check_url_duplicates]]
       end
 
       def file_params(files)

--- a/lib/uploadcare/rest/connections/api_connection.rb
+++ b/lib/uploadcare/rest/connections/api_connection.rb
@@ -24,6 +24,8 @@ module Uploadcare
           frd.response :follow_redirects, limit: 3, callback: lambda{|old, env| auth_strategy.apply(env) }
           frd.response :uploadcare_parse_json
 
+          Array(options[:api_middlewares]).each { |middleware| frd.use(middleware) }
+
           frd.adapter :net_http # actually, default adapter, just to be clear
         end
       end

--- a/lib/uploadcare/rest/connections/upload_connection.rb
+++ b/lib/uploadcare/rest/connections/upload_connection.rb
@@ -14,6 +14,8 @@ module Uploadcare
           frd.response :uploadcare_raise_error
           frd.response :uploadcare_parse_json
 
+          Array(options[:upload_middlewares]).each { |middleware| frd.use(middleware) }
+
           frd.adapter :net_http
         end
       end

--- a/lib/uploadcare/version.rb
+++ b/lib/uploadcare/version.rb
@@ -1,3 +1,3 @@
 module Uploadcare
-  VERSION = '2.1.2'.freeze
+  VERSION = '2.2'.freeze
 end


### PR DESCRIPTION
Adds global and request options for `check_url_duplicates`.

Also adds a way to inject external middlewares into the Faraday connections